### PR TITLE
[Suspense] Try to use lazy to fetch data

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,60 +1,54 @@
 import React, { lazy, Suspense, Component } from 'react';
 //import Gallery from './Gallery'
 
-const Gallery = lazy(() => import('./Gallery'))
+let pictures
+let accessToken
+const Gallery = lazy(() => {
+  return fetch(
+    `https://api.instagram.com/v1/users/self/media/recent/?access_token=${accessToken}`,
+    {
+      method: 'GET',
+      Accept: 'application/json',
+      mode: 'cors',
+    }
+  )
+  .then(response => response.json())
+  .then(res => {
+    pictures = res.data.map(instagramItem => (
+      {
+        id: instagramItem.id,
+        src: instagramItem.images.standard_resolution.url,
+        caption: instagramItem.caption.text,
+      }
+    ))
+
+    return import('./Gallery')
+  })
+})
 
 class App extends Component {
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      accessToken: null,
-      pictures: [],
-    }
-  }
+  state = {}
 
   handleClick = () => {
     window.location.href = 'https://api.instagram.com/oauth/authorize/?client_id=b3f2ba7886a44b2f9e7c6328b5bc6e58&redirect_uri=http://localhost:3001&response_type=token'
   }
 
   static getDerivedStateFromProps(props, state) {
-    if (state.accessToken) return null
+    if (accessToken) return null
 
     const match = window.location.href.match(/#access_token=([\d\w.]*)/)
 
     if (match) {
-      state['accessToken'] = match[1]
+      accessToken = match[1]
     }
 
     return null
   }
 
   componentDidMount() {
-    fetch(
-      `https://api.instagram.com/v1/users/self/media/recent/?access_token=${this.state.accessToken}`,
-      {
-        method: 'GET',
-        Accept: 'application/json',
-        mode: 'cors',
-      }
-    )
-    .then(response => response.json())
-    .then(res => {
-      const pictures = res.data.map(instagramItem => (
-        {
-          id: instagramItem.id,
-          src: instagramItem.images.standard_resolution.url,
-          caption: instagramItem.caption.text,
-        }
-      ))
-
-      this.setState({ pictures })
-    })
   }
 
   render() {
-    const { accessToken, pictures } = this.state
-
     return (
       <div style={ styles }>
         {!accessToken && (
@@ -62,11 +56,9 @@ class App extends Component {
             Show Insta
           </button>
         )}
-        {pictures && (
-          <Suspense fallback={<div>Loading gallery…</div>}>
-            <Gallery pictures={pictures} />
-          </Suspense>
-        )}
+        <Suspense fallback={<div>Loading gallery…</div>}>
+          <Gallery pictures={pictures} />
+        </Suspense>
       </div>
     );
   }


### PR DESCRIPTION
In order to understand how `Suspense` works, I tried to fetch data before import lazily the `Gallery` component using global variables.

**What I understand**
- [Dan fetchers from the future](https://reactjs.org/blog/2018/03/01/sneak-peek-beyond-react-16.html) should handle a state in the `Suspense` component to update props in `children` component,
- Here, my code doesn't work because I am calling `<Gallery pictures={pictures} />` at the moment when `App` is instanciated. So, `pictures` is empty when I pass this prop to my `Suspense` component. It stays empty because of the closure and so, when instanciated after the `import`, the rendering still cannot read the refreshed `pictures` prop.

**Ideas**
We could have use a local cache, `localStorage` for example, to store the `pictures` data and tell the `Gallery` component to use it (instead of passing a prop). But, it would have derivated from the purpose of `React` components rendering, composition and lifecycle.